### PR TITLE
Adds details for install on Mac OS X

### DIFF
--- a/part-0.ipynb
+++ b/part-0.ipynb
@@ -10,7 +10,7 @@
    "name": "python2"
   },
   "name": "",
-  "signature": "sha256:7e77fab303afbbd6ade7a9ab434bf219c12be6e73b5182b90eacad402e5e1b61"
+  "signature": "sha256:bcf9b99fa7aeba5ee12ed312039e072c00cf46f8cd218cd9ce2559061b52e6d6"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -22,23 +22,16 @@
      "level": 1,
      "metadata": {},
      "source": [
-      "Setup (before the workshop)"
+      "Setup"
      ]
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Please complete the instructions on this page before you arrive at the Intro to Python workshop.\n",
+      "**Please complete the instructions on this page before you arrive at the Intro to Python workshop.**\n",
       "\n",
       "Stuck or need help? [Ask for help by describing your error here](https://github.com/pythonsd/intro-to-python/issues/new), in as much detail as possible. Or ask for help through [SD Python](http://www.meetup.com/pythonsd/), [SD Pyladies](http://www.meetup.com/sd-pyladies/), or [IE Pyladies](http://www.meetup.com/iepyladies/)."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "> These instructions are based on tutorials by [Geek Girls Carrots](http://django.carrots.pl/) and [DjangoGirls](http://tutorial.djangogirls.org/python_installation/README.html)."
      ]
     },
     {
@@ -121,24 +114,57 @@
      "level": 2,
      "metadata": {},
      "source": [
-      "OS X"
+      "Mac OS X"
      ]
     },
     {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "You need to go to the website https://www.python.org/downloads/release/python-341/ and download the Python installer:\n",
-      "- download the Mac OS X 64-bit/32-bit installer DMG file,\n",
-      "- double click to open it,\n",
-      "- double click Python.mpkg to run the installer.\n",
+      "Please go to this website page https://www.python.org/downloads/ to download the Python installer:\n",
+      "- click on the `Download Python 3.4.1` button (a yellow button on left side of screen),\n",
+      "- download the Mac OS X 64-bit/32-bit installer dmg file `python-3.4.1-macosx10.6.dmg` and save it to your mac,\n",
+      "- double click the downloaded file to open it and run the installer (Tip: If you forget or can't find where you saved the downloaded file, you may use the magnifying glass in the upper right corner of the screen to search for the file by name.)\n",
       "\n",
-      "Verify the installation was successful by opening the Terminal application and running the python3 command:\n",
+      "\n",
+      "** Verify the installation **\n",
+      "\n",
+      "Verify the installation was successful by opening the Terminal application and running the python3 command by typing <span style=\"color:blue\">python3 --version</span> after the `$` command prompt:\n",
       "```\n",
       "$ python3 --version\n",
       "Python 3.4.1\n",
       "```"
      ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "<span style=\"color:red\">**Are you using Mac OS X 10.5 (a possibility if you have a Mac laptop built before mid-2010)?**</span>  \n",
+      "If you are using Mac OS X 10.5, your installation process will differ slightly. (Tip: You may check your Mac OS X version by selecting the Apple icon in the top left corner of the screen and choosing \"About This Mac\".)</span>\n",
+      "\n",
+      "For Mac OS X 10.5 users only:\n",
+      "- click on this link: https://www.python.org/downloads/release/python-341/\n",
+      "- scroll down to \"Files\" heading and double click on \"Mac OS X 32-bit i386/PPC installer\"\n",
+      "- save the \"Mac OS X 32-bit i386/PPC installer\" dmg file `python-3.4.1-macosx10.5.dmg` to your mac,\n",
+      "- double click the downloaded file to open it and run the installer (Tip: If you forget or can't find where you saved the downloaded file, you may use the magnifying glass in the upper right corner of the screen to search for the file by name.),\n",
+      "- follow the steps above to verify your installation"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "*Attribution: These instructions are partially based on tutorials by [Geek Girls Carrots](http://django.carrots.pl/) and [DjangoGirls](http://tutorial.djangogirls.org/python_installation/README.html).*"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
     }
    ],
    "metadata": {}


### PR DESCRIPTION
@audreyr, @riseriyo: Please give the Mac OS X install instructions a quick scan. 

@alaindomissy: Since most mac users will be using OS X 10.6+, I think it is easier (less error prone) to send them to the main download page and click the yellow button that directly downloads the correct file.

**OS X 10.5**
I added install instructions for those with older macbooks and are still on OS X 10.5 (there are still a few that seem to still be). I put these in a separate cell so easier to delete or hide the cell if preferred.

**A few helpful tips on mac**
I also added a few tips for finding the OS version, finding files on a mac, and clarifying that $ is not typed when entering a command (you may be surprised the frequency of that question).

**Attribution to other groups**
 I moved to the bottom of the doc since it looks a little prettier to my eye. Feel free to move it up if you desire.
