### PR TITLE
Update dict examples and change sets to tuples

### DIFF
--- a/part-4.ipynb
+++ b/part-4.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:c41c7b2462d1eccc5d63748331ca0f9ee5635e45f1f51c325d9a923cc48cc7ad"
+  "signature": "sha256:640caa4f1507ed924c3e826c02125468a1dc8314809695aa3b1b04bcae642559"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -514,19 +514,38 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "## Sets\n",
+      "## Tuples\n",
       "\n",
-      "Sets are unordered collections of distinct items.  Lists can have duplicates of the same item, but sets only store one copy.\n",
+      "Tuples are similar to lists except they're immutable, which means we can't change them after they've been made.\n",
       "\n",
-      "Let's say we want to make a roster of people who have RSVPed to our birthday party.  If someone RSVPs twice we don't want them to show up in our roster twice.  Let's use a set!"
+      "Tuples are comma-separated lists:"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "party_roster = {\"Jessica\", \"Tom\", \"Alice\"}\n",
-      "party_roster"
+      "stuff = (1, 2, \"hello\")"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "stuff"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "type(stuff)"
      ],
      "language": "python",
      "metadata": {},
@@ -536,15 +555,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Notice how we used curly braces around our set (just like we did for dictionaries)?  What happens if we want to represent an empty set?"
+      "The parenthesis are often optional.  They're often added for clarity.  This should work too:"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "empty_dictionary = {}\n",
-      "type(empty_dictionary)"
+      "stuff = 1, 2, 3"
      ],
      "language": "python",
      "metadata": {},
@@ -554,8 +572,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "empty_set = set()\n",
-      "type(empty_set)"
+      "stuff"
      ],
      "language": "python",
      "metadata": {},
@@ -565,14 +582,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Our friend Jeremy just RSVPed, let's add him to our set too:"
+      "Let's see what happens when we try to change our tuple:"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "party_roster.add(\"Jeremy\")"
+      "stuff[2] = 3"
      ],
      "language": "python",
      "metadata": {},
@@ -582,34 +599,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "We can check for size and membership of sets and loop over them just like with sets, strings, and dictionaries."
+      "We can make an empty tuple with an empty set of parenthesis:"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "\"Jessica\" in party_roster"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "\"Bill\" in party_roster"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "len(party_roster)"
+      "empty = ()"
      ],
      "language": "python",
      "metadata": {},
@@ -619,15 +616,34 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Our party is a potluck.  Everyone is supposed to bring a dinner dish or a dessert.  Let's make sets for everyone bringing a dish and everyone bringing a dessert."
+      "Any guesses how we can make a single-item tuple?"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "bringing_dish = {\"Jessica\", \"Jeremy\"}\n",
-      "bringing_dessert = {\"Alice\", \"Jeremy\"}"
+      "things = (3)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "things"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "type(things)"
      ],
      "language": "python",
      "metadata": {},
@@ -637,17 +653,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Sets allow us to use set operations from math to find the union, intersection, difference, and symmetric difference between sets.  Let's try it out:"
+      "Python just sees this as a number with parenthesis around it.  The commas are the important part.  We need to add a comma after the number to make a single-item tuple:"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "bringing_dish_or_dessert = bringing_dish.union(bringing_dessert)\n",
-      "bringing_dish_and_dessert = bringing_dish.intersection(bringing_dessert)\n",
-      "bringing_just_one_item = bringing_dish.symmetric_difference(bringing_dessert)\n",
-      "not_bringing_food = party_roster.difference(bringing_dish_or_dessert)"
+      "things = (3,)"
      ],
      "language": "python",
      "metadata": {},
@@ -657,10 +670,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print(bringing_dish_or_dessert)\n",
-      "print(bringing_dish_and_dessert)\n",
-      "print(bringing_just_one_item)\n",
-      "print(not_bringing_food)"
+      "things"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
I simplified the dictionary examples because I felt they were getting very long and required a lot of typing.

I replaced the set explanation with tuples because sets are briefly explained in part 2.  I'm not sure the tuple example adds much value so we can leave it out if desired.
